### PR TITLE
Update dependencies on actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
           distribution: 'temurin'
       - name: Make Gradle wrapper runnable on Unix
         run: chmod +x ./gradlew
-      - name: build
+      - name: Build
         run: ./gradlew build
       - name: Upload Build Artifacts
         if: ${{ runner.os == 'Linux' && matrix.java == '8' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'temurin'
       - name: Make Gradle wrapper runnable on Unix
         run: chmod +x ./gradlew
       - name: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,28 +5,25 @@ jobs:
   build:
     strategy:
       matrix:
-        # Use these Java versions
-        java: [
-          8
-        ]
-        os: [ubuntu-latest]
+        java: ["8"]
+        os: ["ubuntu-22.04"]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: checkout repository
-        uses: actions/checkout@v2
-      - name: validate gradle wrapper
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+      - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
-      - name: setup jdk ${{ matrix.java }}
-        uses: actions/setup-java@v1
+      - name: Setup JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
-      - name: make gradle wrapper executable
+      - name: Make Gradle wrapper runnable on Unix
         run: chmod +x ./gradlew
       - name: build
         run: ./gradlew build
-      - name: capture build artifacts
+      - name: Upload Build Artifacts
         if: ${{ runner.os == 'Linux' && matrix.java == '8' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ViaForge-1.12.2
           path: build/libs/


### PR DESCRIPTION
This updates the GitHub actions script to include the newer dependencies in order to resolve GitHub's complaint about old nodejs becoming deprecated when using older versions of checkout, setup-java and upload-artifact.