### PR TITLE
GH cache to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,15 @@ jobs:
           java-version: 8
           distribution: 'temurin'
           check-latest: true
+      - name: Cache Dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Build with Gradle
         run: ./gradlew shadowJar
       - name: Upload Build Artifacts


### PR DESCRIPTION
Caches the dependencies in CI to decrease building times, this requires testing before merging - Feel free to send improvements if this is incorrect.