### PR TITLE
Moved the ViaForgeCommon#init call into an FMLCommonSetupEvent listener

### DIFF
--- a/src/main/java/de/florianmichael/viaforge/common/ViaForgeCommon.java
+++ b/src/main/java/de/florianmichael/viaforge/common/ViaForgeCommon.java
@@ -25,9 +25,9 @@ import com.viaversion.viaversion.protocol.ProtocolPipelineImpl;
 import de.florianmichael.viaforge.common.platform.VFPlatform;
 import de.florianmichael.viaforge.common.platform.ViaForgeConfig;
 import de.florianmichael.viaforge.common.protocoltranslator.ViaForgeVLInjector;
+import de.florianmichael.viaforge.common.protocoltranslator.ViaForgeVLLoader;
 import de.florianmichael.viaforge.common.protocoltranslator.netty.VFNetworkManager;
 import de.florianmichael.viaforge.common.protocoltranslator.netty.ViaForgeVLLegacyPipeline;
-import de.florianmichael.viaforge.common.protocoltranslator.ViaForgeVLLoader;
 import io.netty.channel.Channel;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.util.AttributeKey;
@@ -63,9 +63,6 @@ public class ViaForgeCommon {
      * @param platform the platform fields
      */
     public static void init(final VFPlatform platform) {
-        if (manager != null) {
-            return; // Already initialized, ignore it then :tm:
-        }
         final ProtocolVersion version = ProtocolVersion.getProtocol(platform.getGameVersion()); // ViaForge will only load on post-netty versions
         if (version == ProtocolVersion.unknown) {
             throw new IllegalArgumentException("Unknown version " + platform.getGameVersion());

--- a/viaforge-mc112/src/main/java/de/florianmichael/viaforge/ViaForge112.java
+++ b/viaforge-mc112/src/main/java/de/florianmichael/viaforge/ViaForge112.java
@@ -18,12 +18,14 @@
 
 package de.florianmichael.viaforge;
 
+import de.florianmichael.viaforge.common.ViaForgeCommon;
 import de.florianmichael.viaforge.common.platform.VFPlatform;
 import de.florianmichael.viaforge.provider.ViaForgeGameProfileFetcher;
 import net.minecraft.client.Minecraft;
 import net.minecraft.realms.RealmsSharedConstants;
 import net.minecraft.util.Session;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.raphimc.vialegacy.protocols.release.protocol1_8to1_7_6_10.providers.GameProfileFetcher;
 
 import java.io.File;
@@ -32,7 +34,10 @@ import java.util.function.Supplier;
 @Mod(modid = "viaforge")
 public class ViaForge112 implements VFPlatform {
 
-    public static final ViaForge112 PLATFORM = new ViaForge112();
+    @Mod.EventHandler
+    public void onInit(FMLInitializationEvent event) {
+        ViaForgeCommon.init(this);
+    }
 
     @Override
     public int getGameVersion() {

--- a/viaforge-mc112/src/main/java/de/florianmichael/viaforge/mixin/impl/MixinGuiMainMenu.java
+++ b/viaforge-mc112/src/main/java/de/florianmichael/viaforge/mixin/impl/MixinGuiMainMenu.java
@@ -19,11 +19,12 @@
 package de.florianmichael.viaforge.mixin.impl;
 
 import com.viaversion.viaversion.util.Pair;
-import de.florianmichael.viaforge.ViaForge112;
 import de.florianmichael.viaforge.common.ViaForgeCommon;
 import de.florianmichael.viaforge.common.platform.ViaForgeConfig;
 import de.florianmichael.viaforge.gui.GuiProtocolSelector;
-import net.minecraft.client.gui.*;
+import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.gui.GuiMainMenu;
+import net.minecraft.client.gui.GuiScreen;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -34,8 +35,6 @@ public class MixinGuiMainMenu extends GuiScreen {
 
     @Inject(method = "initGui", at = @At("RETURN"))
     public void hookViaForgeButton(CallbackInfo ci) {
-        ViaForgeCommon.init(ViaForge112.PLATFORM);
-
         final ViaForgeConfig config = ViaForgeCommon.getManager().getConfig();
         if (config.isShowMainMenuButton()) {
             final Pair<Integer, Integer> pos = config.getViaForgeButtonPosition().getPosition(this.width, this.height);

--- a/viaforge-mc116/src/main/java/de/florianmichael/viaforge/ViaForge116.java
+++ b/viaforge-mc116/src/main/java/de/florianmichael/viaforge/ViaForge116.java
@@ -36,10 +36,10 @@ import java.util.function.Supplier;
 public class ViaForge116 implements VFPlatform {
 
     public ViaForge116() {
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onPostInit);
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onInit);
     }
 
-    public void onPostInit(FMLCommonSetupEvent event) {
+    public void onInit(FMLCommonSetupEvent event) {
         ViaForgeCommon.init(this);
     }
 

--- a/viaforge-mc116/src/main/java/de/florianmichael/viaforge/ViaForge116.java
+++ b/viaforge-mc116/src/main/java/de/florianmichael/viaforge/ViaForge116.java
@@ -18,12 +18,15 @@
 
 package de.florianmichael.viaforge;
 
+import de.florianmichael.viaforge.common.ViaForgeCommon;
 import de.florianmichael.viaforge.common.platform.VFPlatform;
 import de.florianmichael.viaforge.provider.ViaForgeGameProfileFetcher;
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.Session;
 import net.minecraft.util.SharedConstants;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.raphimc.vialegacy.protocols.release.protocol1_8to1_7_6_10.providers.GameProfileFetcher;
 
 import java.io.File;
@@ -32,7 +35,13 @@ import java.util.function.Supplier;
 @Mod("viaforge")
 public class ViaForge116 implements VFPlatform {
 
-    public static final ViaForge116 PLATFORM = new ViaForge116();
+    public ViaForge116() {
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onPostInit);
+    }
+
+    public void onPostInit(FMLCommonSetupEvent event) {
+        ViaForgeCommon.init(this);
+    }
 
     @Override
     public int getGameVersion() {

--- a/viaforge-mc116/src/main/java/de/florianmichael/viaforge/mixin/MixinMainMenuScreen.java
+++ b/viaforge-mc116/src/main/java/de/florianmichael/viaforge/mixin/MixinMainMenuScreen.java
@@ -19,7 +19,6 @@
 package de.florianmichael.viaforge.mixin;
 
 import com.viaversion.viaversion.util.Pair;
-import de.florianmichael.viaforge.ViaForge116;
 import de.florianmichael.viaforge.common.ViaForgeCommon;
 import de.florianmichael.viaforge.common.platform.ViaForgeConfig;
 import de.florianmichael.viaforge.gui.GuiProtocolSelector;
@@ -42,8 +41,6 @@ public class MixinMainMenuScreen extends Screen {
 
     @Inject(method = "init", at = @At("RETURN"))
     public void hookViaForgeButton(CallbackInfo ci) {
-        ViaForgeCommon.init(ViaForge116.PLATFORM);
-
         final ViaForgeConfig config = ViaForgeCommon.getManager().getConfig();
         if (config.isShowMainMenuButton()) {
             final Pair<Integer, Integer> pos = config.getViaForgeButtonPosition().getPosition(this.width, this.height);

--- a/viaforge-mc117/src/main/java/de/florianmichael/viaforge/ViaForge117.java
+++ b/viaforge-mc117/src/main/java/de/florianmichael/viaforge/ViaForge117.java
@@ -18,12 +18,15 @@
 
 package de.florianmichael.viaforge;
 
+import de.florianmichael.viaforge.common.ViaForgeCommon;
 import de.florianmichael.viaforge.common.platform.VFPlatform;
 import de.florianmichael.viaforge.provider.ViaForgeGameProfileFetcher;
 import net.minecraft.SharedConstants;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.User;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.raphimc.vialegacy.protocols.release.protocol1_8to1_7_6_10.providers.GameProfileFetcher;
 
 import java.io.File;
@@ -32,7 +35,13 @@ import java.util.function.Supplier;
 @Mod("viaforge")
 public class ViaForge117 implements VFPlatform {
 
-    public static final ViaForge117 PLATFORM = new ViaForge117();
+    public ViaForge117() {
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onPostInit);
+    }
+
+    public void onPostInit(FMLCommonSetupEvent event) {
+        ViaForgeCommon.init(this);
+    }
 
     @Override
     public int getGameVersion() {

--- a/viaforge-mc117/src/main/java/de/florianmichael/viaforge/ViaForge117.java
+++ b/viaforge-mc117/src/main/java/de/florianmichael/viaforge/ViaForge117.java
@@ -36,10 +36,10 @@ import java.util.function.Supplier;
 public class ViaForge117 implements VFPlatform {
 
     public ViaForge117() {
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onPostInit);
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onInit);
     }
 
-    public void onPostInit(FMLCommonSetupEvent event) {
+    public void onInit(FMLCommonSetupEvent event) {
         ViaForgeCommon.init(this);
     }
 

--- a/viaforge-mc117/src/main/java/de/florianmichael/viaforge/mixin/MixinTitleScreen.java
+++ b/viaforge-mc117/src/main/java/de/florianmichael/viaforge/mixin/MixinTitleScreen.java
@@ -42,8 +42,6 @@ public class MixinTitleScreen extends Screen {
 
     @Inject(method = "init", at = @At("RETURN"))
     public void hookViaForgeButton(CallbackInfo ci) {
-        ViaForgeCommon.init(ViaForge117.PLATFORM);
-
         final ViaForgeConfig config = ViaForgeCommon.getManager().getConfig();
         if (config.isShowMainMenuButton()) {
             final Pair<Integer, Integer> pos = config.getViaForgeButtonPosition().getPosition(this.width, this.height);

--- a/viaforge-mc118/src/main/java/de/florianmichael/viaforge/ViaForge118.java
+++ b/viaforge-mc118/src/main/java/de/florianmichael/viaforge/ViaForge118.java
@@ -18,12 +18,15 @@
 
 package de.florianmichael.viaforge;
 
+import de.florianmichael.viaforge.common.ViaForgeCommon;
 import de.florianmichael.viaforge.common.platform.VFPlatform;
 import de.florianmichael.viaforge.provider.ViaForgeGameProfileFetcher;
 import net.minecraft.SharedConstants;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.User;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.raphimc.vialegacy.protocols.release.protocol1_8to1_7_6_10.providers.GameProfileFetcher;
 
 import java.io.File;
@@ -32,7 +35,13 @@ import java.util.function.Supplier;
 @Mod("viaforge")
 public class ViaForge118 implements VFPlatform {
 
-    public static final ViaForge118 PLATFORM = new ViaForge118();
+    public ViaForge118() {
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onPostInit);
+    }
+
+    private void onPostInit(FMLCommonSetupEvent event) {
+        ViaForgeCommon.init(this);
+    }
 
     @Override
     public int getGameVersion() {

--- a/viaforge-mc118/src/main/java/de/florianmichael/viaforge/ViaForge118.java
+++ b/viaforge-mc118/src/main/java/de/florianmichael/viaforge/ViaForge118.java
@@ -36,10 +36,10 @@ import java.util.function.Supplier;
 public class ViaForge118 implements VFPlatform {
 
     public ViaForge118() {
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onPostInit);
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onInit);
     }
 
-    private void onPostInit(FMLCommonSetupEvent event) {
+    private void onInit(FMLCommonSetupEvent event) {
         ViaForgeCommon.init(this);
     }
 

--- a/viaforge-mc118/src/main/java/de/florianmichael/viaforge/mixin/MixinTitleScreen.java
+++ b/viaforge-mc118/src/main/java/de/florianmichael/viaforge/mixin/MixinTitleScreen.java
@@ -19,7 +19,6 @@
 package de.florianmichael.viaforge.mixin;
 
 import com.viaversion.viaversion.util.Pair;
-import de.florianmichael.viaforge.ViaForge118;
 import de.florianmichael.viaforge.common.ViaForgeCommon;
 import de.florianmichael.viaforge.common.platform.ViaForgeConfig;
 import de.florianmichael.viaforge.gui.GuiProtocolSelector;
@@ -42,8 +41,6 @@ public class MixinTitleScreen extends Screen {
 
     @Inject(method = "init", at = @At("RETURN"))
     public void hookViaForgeButton(CallbackInfo ci) {
-        ViaForgeCommon.init(ViaForge118.PLATFORM);
-
         final ViaForgeConfig config = ViaForgeCommon.getManager().getConfig();
         if (config.isShowMainMenuButton()) {
             final Pair<Integer, Integer> pos = config.getViaForgeButtonPosition().getPosition(this.width, this.height);

--- a/viaforge-mc119/src/main/java/de/florianmichael/viaforge/ViaForge119.java
+++ b/viaforge-mc119/src/main/java/de/florianmichael/viaforge/ViaForge119.java
@@ -18,12 +18,15 @@
 
 package de.florianmichael.viaforge;
 
+import de.florianmichael.viaforge.common.ViaForgeCommon;
 import de.florianmichael.viaforge.common.platform.VFPlatform;
 import de.florianmichael.viaforge.provider.ViaForgeGameProfileFetcher;
 import net.minecraft.SharedConstants;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.User;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.raphimc.vialegacy.protocols.release.protocol1_8to1_7_6_10.providers.GameProfileFetcher;
 
 import java.io.File;
@@ -32,7 +35,13 @@ import java.util.function.Supplier;
 @Mod("viaforge")
 public class ViaForge119 implements VFPlatform {
 
-    public static final ViaForge119 PLATFORM = new ViaForge119();
+    public ViaForge119() {
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onPostInit);
+    }
+
+    private void onPostInit(FMLCommonSetupEvent event) {
+        ViaForgeCommon.init(this);
+    }
 
     @Override
     public int getGameVersion() {

--- a/viaforge-mc119/src/main/java/de/florianmichael/viaforge/ViaForge119.java
+++ b/viaforge-mc119/src/main/java/de/florianmichael/viaforge/ViaForge119.java
@@ -36,10 +36,10 @@ import java.util.function.Supplier;
 public class ViaForge119 implements VFPlatform {
 
     public ViaForge119() {
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onPostInit);
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onInit);
     }
 
-    private void onPostInit(FMLCommonSetupEvent event) {
+    private void onInit(FMLCommonSetupEvent event) {
         ViaForgeCommon.init(this);
     }
 

--- a/viaforge-mc119/src/main/java/de/florianmichael/viaforge/mixin/MixinTitleScreen.java
+++ b/viaforge-mc119/src/main/java/de/florianmichael/viaforge/mixin/MixinTitleScreen.java
@@ -19,7 +19,6 @@
 package de.florianmichael.viaforge.mixin;
 
 import com.viaversion.viaversion.util.Pair;
-import de.florianmichael.viaforge.ViaForge119;
 import de.florianmichael.viaforge.common.ViaForgeCommon;
 import de.florianmichael.viaforge.common.platform.ViaForgeConfig;
 import de.florianmichael.viaforge.gui.GuiProtocolSelector;
@@ -41,8 +40,6 @@ public class MixinTitleScreen extends Screen {
 
     @Inject(method = "init", at = @At("RETURN"))
     public void hookViaForgeButton(CallbackInfo ci) {
-        ViaForgeCommon.init(ViaForge119.PLATFORM);
-
         final ViaForgeConfig config = ViaForgeCommon.getManager().getConfig();
         if (config.isShowMainMenuButton()) {
             final Pair<Integer, Integer> pos = config.getViaForgeButtonPosition().getPosition(this.width, this.height);

--- a/viaforge-mc120/src/main/java/de/florianmichael/viaforge/ViaForge120.java
+++ b/viaforge-mc120/src/main/java/de/florianmichael/viaforge/ViaForge120.java
@@ -36,10 +36,10 @@ import java.util.function.Supplier;
 public class ViaForge120 implements VFPlatform {
 
     public ViaForge120() {
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onPostInit);
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onInit);
     }
 
-    private void onPostInit(FMLCommonSetupEvent event) {
+    private void onInit(FMLCommonSetupEvent event) {
         ViaForgeCommon.init(this);
     }
 

--- a/viaforge-mc120/src/main/java/de/florianmichael/viaforge/ViaForge120.java
+++ b/viaforge-mc120/src/main/java/de/florianmichael/viaforge/ViaForge120.java
@@ -18,12 +18,15 @@
 
 package de.florianmichael.viaforge;
 
+import de.florianmichael.viaforge.common.ViaForgeCommon;
 import de.florianmichael.viaforge.common.platform.VFPlatform;
 import de.florianmichael.viaforge.provider.ViaForgeGameProfileFetcher;
 import net.minecraft.SharedConstants;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.User;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.raphimc.vialegacy.protocols.release.protocol1_8to1_7_6_10.providers.GameProfileFetcher;
 
 import java.io.File;
@@ -32,7 +35,13 @@ import java.util.function.Supplier;
 @Mod("viaforge")
 public class ViaForge120 implements VFPlatform {
 
-    public static final ViaForge120 PLATFORM = new ViaForge120();
+    public ViaForge120() {
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onPostInit);
+    }
+
+    private void onPostInit(FMLCommonSetupEvent event) {
+        ViaForgeCommon.init(this);
+    }
 
     @Override
     public int getGameVersion() {

--- a/viaforge-mc120/src/main/java/de/florianmichael/viaforge/mixin/MixinTitleScreen.java
+++ b/viaforge-mc120/src/main/java/de/florianmichael/viaforge/mixin/MixinTitleScreen.java
@@ -19,7 +19,6 @@
 package de.florianmichael.viaforge.mixin;
 
 import com.viaversion.viaversion.util.Pair;
-import de.florianmichael.viaforge.ViaForge120;
 import de.florianmichael.viaforge.common.ViaForgeCommon;
 import de.florianmichael.viaforge.common.platform.ViaForgeConfig;
 import de.florianmichael.viaforge.gui.GuiProtocolSelector;
@@ -41,8 +40,6 @@ public class MixinTitleScreen extends Screen {
 
     @Inject(method = "init", at = @At("RETURN"))
     public void hookViaForgeButton(CallbackInfo ci) {
-        ViaForgeCommon.init(ViaForge120.PLATFORM);
-
         final ViaForgeConfig config = ViaForgeCommon.getManager().getConfig();
         if (config.isShowMainMenuButton()) {
             final Pair<Integer, Integer> pos = config.getViaForgeButtonPosition().getPosition(this.width, this.height);


### PR DESCRIPTION
In this pull request, I utilized the Forge setup event to initialize ViaForge instead of the main menu initialization.

Why?
This change ensures a more reliable initialization of ViaForge, as the main menu not loading would previously result in a null pointer crash.