### PR TITLE
Fix #245: Resolve unexpected teleport confirmation ID kick on 1.9+ servers

### DIFF
--- a/viaforge-mc189/src/main/java/com/viaversion/viaforge/mixin/impl/MixinNetHandlerPlayClient.java
+++ b/viaforge-mc189/src/main/java/com/viaversion/viaforge/mixin/impl/MixinNetHandlerPlayClient.java
@@ -18,7 +18,7 @@
 
 package com.viaversion.viaforge.mixin.impl;
 
-import com.viaversion.viaforge.mixin.impl.interfaces.IS08;
+import com.viaversion.viaforge.mixin.interfaces.IS08;
 import com.viaversion.viarewind.protocol.v1_9to1_8.Protocol1_9To1_8;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;

--- a/viaforge-mc189/src/main/java/com/viaversion/viaforge/mixin/impl/MixinNetHandlerPlayClient.java
+++ b/viaforge-mc189/src/main/java/com/viaversion/viaforge/mixin/impl/MixinNetHandlerPlayClient.java
@@ -18,12 +18,19 @@
 
 package com.viaversion.viaforge.mixin.impl;
 
+import com.viaversion.viaforge.mixin.impl.interfaces.IS08;
+import com.viaversion.viarewind.protocol.v1_9to1_8.Protocol1_9To1_8;
 import com.viaversion.viaversion.api.connection.UserConnection;
+import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.connection.ConnectionDetails;
 import com.viaversion.viaforge.common.ViaForgeCommon;
+import com.viaversion.viaversion.protocols.v1_8to1_9.packet.ServerboundPackets1_9;
 import io.netty.channel.Channel;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.network.NetHandlerPlayClient;
+import net.minecraft.network.play.server.S08PacketPlayerPosLook;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -43,4 +50,18 @@ public class MixinNetHandlerPlayClient {
         ConnectionDetails.sendConnectionDetails(connection, ConnectionDetails.MOD_CHANNEL);
     }
 
+    @Inject(method = "handlePlayerPosLook", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayer;setPositionAndRotation(DDDFF)V", shift = At.Shift.AFTER))
+    public void handleTeleportPacket(S08PacketPlayerPosLook packetIn, CallbackInfo ci) {
+        final Channel channel = Minecraft.getMinecraft().thePlayer.sendQueue.getNetworkManager().channel();
+        final UserConnection connection = channel.attr(ViaForgeCommon.VF_VIA_USER).get();
+        if (connection == null) {
+            return;
+        }
+
+        if (ViaForgeCommon.getManager().getTargetVersion().newerThanOrEqualTo(ProtocolVersion.v1_9)) {
+            PacketWrapper packet = PacketWrapper.create(ServerboundPackets1_9.ACCEPT_TELEPORTATION, connection);
+            packet.write(Types.VAR_INT, ((IS08)packetIn).getTeleportId());
+            packet.sendToServer(Protocol1_9To1_8.class);
+        }
+    }
 }

--- a/viaforge-mc189/src/main/java/com/viaversion/viaforge/mixin/impl/MixinS08PacketPlayerPosLook.java
+++ b/viaforge-mc189/src/main/java/com/viaversion/viaforge/mixin/impl/MixinS08PacketPlayerPosLook.java
@@ -19,8 +19,12 @@
 package com.viaversion.viaforge.mixin.impl;
 
 import com.viaversion.viaforge.common.ViaForgeCommon;
-import com.viaversion.viaforge.mixin.impl.interfaces.IS08;
+import com.viaversion.viaforge.mixin.interfaces.IS08;
+import com.viaversion.viarewind.protocol.v1_9to1_8.storage.PlayerPositionTracker;
+import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+import io.netty.channel.Channel;
+import net.minecraft.client.Minecraft;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.network.play.server.S08PacketPlayerPosLook;
 import org.spongepowered.asm.mixin.Mixin;
@@ -39,7 +43,14 @@ public class MixinS08PacketPlayerPosLook implements IS08 {
     @Inject(method = "readPacketData", at = @At("RETURN"))
     public void onReadPacketData(PacketBuffer buf, CallbackInfo ci) throws IOException {
         if (ViaForgeCommon.getManager().getTargetVersion().newerThanOrEqualTo(ProtocolVersion.v1_9)) {
-            this.teleportId = buf.readVarIntFromBuffer();
+            Channel channel = Minecraft.getMinecraft().thePlayer.sendQueue.getNetworkManager().channel();
+            UserConnection connection = channel.attr(ViaForgeCommon.VF_VIA_USER).get();
+            if (connection != null) {
+                PlayerPositionTracker tracker = connection.get(PlayerPositionTracker.class);
+                if (tracker != null) {
+                    this.teleportId = tracker.getConfirmId();
+                }
+            }
         }
     }
 

--- a/viaforge-mc189/src/main/java/com/viaversion/viaforge/mixin/impl/MixinS08PacketPlayerPosLook.java
+++ b/viaforge-mc189/src/main/java/com/viaversion/viaforge/mixin/impl/MixinS08PacketPlayerPosLook.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of ViaForge - https://github.com/ViaVersion/ViaForge
+ * Copyright (C) 2021-2026 Florian Reuth <git@florianreuth.de> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.viaversion.viaforge.mixin.impl;
+
+import com.viaversion.viaforge.common.ViaForgeCommon;
+import com.viaversion.viaforge.mixin.impl.interfaces.IS08;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.network.play.server.S08PacketPlayerPosLook;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import java.io.IOException;
+
+@Mixin(S08PacketPlayerPosLook.class)
+public class MixinS08PacketPlayerPosLook implements IS08 {
+
+    @Unique
+    private int teleportId;
+
+    @Inject(method = "readPacketData", at = @At("RETURN"))
+    public void onReadPacketData(PacketBuffer buf, CallbackInfo ci) throws IOException {
+        if (ViaForgeCommon.getManager().getTargetVersion().newerThanOrEqualTo(ProtocolVersion.v1_9)) {
+            this.teleportId = buf.readVarIntFromBuffer();
+        }
+    }
+
+    @Override
+    public int getTeleportId() {
+        return this.teleportId;
+    }
+}

--- a/viaforge-mc189/src/main/java/com/viaversion/viaforge/mixin/impl/interfaces/IS08.java
+++ b/viaforge-mc189/src/main/java/com/viaversion/viaforge/mixin/impl/interfaces/IS08.java
@@ -1,0 +1,24 @@
+/*
+ * This file is part of ViaForge - https://github.com/ViaVersion/ViaForge
+ * Copyright (C) 2021-2026 Florian Reuth <git@florianreuth.de> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.viaversion.viaforge.mixin.impl.interfaces;
+
+public interface IS08 {
+
+    int getTeleportId();
+}

--- a/viaforge-mc189/src/main/java/com/viaversion/viaforge/mixin/interfaces/IS08.java
+++ b/viaforge-mc189/src/main/java/com/viaversion/viaforge/mixin/interfaces/IS08.java
@@ -16,9 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.viaversion.viaforge.mixin.impl.interfaces;
+package com.viaversion.viaforge.mixin.interfaces;
 
 public interface IS08 {
-
     int getTeleportId();
 }

--- a/viaforge-mc189/src/main/resources/mixins.viaforge.json
+++ b/viaforge-mc189/src/main/resources/mixins.viaforge.json
@@ -11,6 +11,7 @@
     "MixinGuiScreenAddServer",
     "MixinGuiScreenServerList",
     "MixinNetHandlerPlayClient",
+    "MixinS08PacketPlayerPosLook",
     "MixinServerData",
     "compatibility.patcher.MixinProtocolVersionDetector",
     "connect.MixinGuiConnecting_1",


### PR DESCRIPTION
### Description
This PR addresses Issue #245, where 1.8.9 clients get kicked with the error `Unexpected teleport confirmation id` when playing on 1.9+ servers. 

### Root Cause
In 1.9+ protocols, servers append a `teleportId` to `S08PacketPlayerPosLook` and mandate an `ACCEPT_TELEPORTATION` response before processing subsequent client movements. Since pure 1.8.9 clients lack this logic, the teleport ID mismatch or omission causes the server to either infinitely rubberband the player or outright kick them for sending invalid confirmation IDs.

Closes #245